### PR TITLE
ci: add prettier and eslint to format front code

### DIFF
--- a/app/.eslintrc.js
+++ b/app/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  root: true,
+  extends: [
+    'plugin:vue/essential',
+    'plugin:prettier/recommended',
+    'eslint:recommended'
+  ]
+}

--- a/app/.prettierrc
+++ b/app/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": false,
+  "arrowParens": "always",
+  "singleQuote": true,
+  "tabWidth": 2
+}

--- a/app/package.json
+++ b/app/package.json
@@ -4,11 +4,15 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve --port 3000",
-    "build": "vue-cli-service build"
+    "build": "vue-cli-service build",
+    "lint-fix": "prettier-eslint --write \"$PWD/src/**/*.{vue,js}\""
   },
   "dependencies": {
     "@fullhuman/postcss-purgecss": "^2.0.5",
     "core-js": "^3.4.3",
+    "eslint": "^6.8.0",
+    "eslint-plugin-vue": "^6.1.2",
+    "prettier-eslint-cli": "^5.0.0",
     "tailwindcss": "^1.1.4",
     "vue": "^2.6.10",
     "vue-burger-menu": "^2.0.3",
@@ -20,6 +24,9 @@
     "@vue/cli-plugin-router": "^4.1.0",
     "@vue/cli-plugin-vuex": "^4.1.0",
     "@vue/cli-service": "^4.1.0",
+    "eslint-config-prettier": "^6.10.0",
+    "eslint-plugin-prettier": "^3.1.2",
+    "prettier": "^1.19.1",
     "vue-template-compiler": "^2.6.10"
   }
 }

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -10,13 +10,13 @@
 </template>
 
 <script>
-import AppMenu from "@/components/AppMenu";
+import AppMenu from '@/components/AppMenu'
 
 export default {
   components: {
     AppMenu
   }
-};
+}
 </script>
 
 <style lang="css" scoped>

--- a/app/src/components/AppMenu.vue
+++ b/app/src/components/AppMenu.vue
@@ -2,7 +2,11 @@
   <Slide>
     <router-link to="/movie" class="flex items-center mb-10">
       <div>
-        <img src="@/assets/img/avatar.jpg" alt="avatar" class="rounded-full w-12 h-12" />
+        <img
+          src="@/assets/img/avatar.jpg"
+          alt="avatar"
+          class="rounded-full w-12 h-12"
+        />
       </div>
       <div class="text-gray-500 ml-6 hover:text-gray-300">Brian</div>
     </router-link>
@@ -67,7 +71,13 @@
       <span>Originals</span>
     </router-link>
     <router-link to="/movie">
-      <svg fill="currentColor" viewBox="0 0 24 24" width="24" height="24" class="icon-cog">
+      <svg
+        fill="currentColor"
+        viewBox="0 0 24 24"
+        width="24"
+        height="24"
+        class="icon-cog"
+      >
         <path
           class="primary"
           d="M6.8 3.45c.87-.52 1.82-.92 2.83-1.17a2.5 2.5 0 0 0 4.74 0c1.01.25 1.96.65 2.82 1.17a2.5 2.5 0 0 0 3.36 3.36c.52.86.92 1.8 1.17 2.82a2.5 2.5 0 0 0 0 4.74c-.25 1.01-.65 1.96-1.17 2.82a2.5 2.5 0 0 0-3.36 3.36c-.86.52-1.8.92-2.82 1.17a2.5 2.5 0 0 0-4.74 0c-1.01-.25-1.96-.65-2.82-1.17a2.5 2.5 0 0 0-3.36-3.36 9.94 9.94 0 0 1-1.17-2.82 2.5 2.5 0 0 0 0-4.74c.25-1.01.65-1.96 1.17-2.82a2.5 2.5 0 0 0 3.36-3.36zM12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8z"
@@ -78,17 +88,19 @@
     </router-link>
 
     <div class="ml-8">
-      <h2 class="text-white font-bold uppercase font-serif text-2xl">Hypertube</h2>
+      <h2 class="text-white font-bold uppercase font-serif text-2xl">
+        Hypertube
+      </h2>
     </div>
   </Slide>
 </template>
 
 <script>
-import { Slide } from "vue-burger-menu";
+import { Slide } from 'vue-burger-menu'
 
 export default {
   components: {
     Slide
   }
-};
+}
 </script>

--- a/app/src/components/MovieThumbnail.vue
+++ b/app/src/components/MovieThumbnail.vue
@@ -8,10 +8,9 @@
 
 <script>
 export default {
-    name: "MovieThumbnail"
+  name: 'MovieThumbnail'
 }
 </script>
-
 
 <style lang="css" scoped>
 .movie-thumbnail {

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -2,12 +2,12 @@ import Vue from 'vue'
 import App from './App.vue'
 import router from './router'
 import store from './store'
-import './assets/styles/app.css';
+import './assets/styles/app.css'
 
 Vue.config.productionTip = false
 
 new Vue({
   router,
   store,
-  render: h => h(App)
+  render: (h) => h(App)
 }).$mount('#app')

--- a/app/src/router/index.js
+++ b/app/src/router/index.js
@@ -16,7 +16,8 @@ const routes = [
     // route level code-splitting
     // this generates a separate chunk (about.[hash].js) for this route
     // which is lazy-loaded when the route is visited.
-    component: () => import(/* webpackChunkName: "about" */ '../views/Movie.vue')
+    component: () =>
+      import(/* webpackChunkName: "about" */ '../views/Movie.vue')
   }
 ]
 

--- a/app/src/store/index.js
+++ b/app/src/store/index.js
@@ -4,12 +4,8 @@ import Vuex from 'vuex'
 Vue.use(Vuex)
 
 export default new Vuex.Store({
-  state: {
-  },
-  mutations: {
-  },
-  actions: {
-  },
-  modules: {
-  }
+  state: {},
+  mutations: {},
+  actions: {},
+  modules: {}
 })

--- a/app/src/views/Home.vue
+++ b/app/src/views/Home.vue
@@ -2,7 +2,11 @@
   <div class="w-full container overflow-hidden mx-auto min-h-screen">
     <div class="px-2">
       <div class="flex flex-wrap -mx-2">
-        <div v-for="i in number_of_movies" :key="i" class="w-full md:w-1/3 lg:w-1/5 p-2">
+        <div
+          v-for="i in number_of_movies"
+          :key="i"
+          class="w-full md:w-1/3 lg:w-1/5 p-2"
+        >
           <movie-thumbnail />
         </div>
       </div>
@@ -11,10 +15,10 @@
 </template>
 
 <script>
-import MovieThumbnail from "@/components/MovieThumbnail.vue";
+import MovieThumbnail from '@/components/MovieThumbnail.vue'
 
 export default {
-  name: "home",
+  name: 'home',
   components: {
     MovieThumbnail
   },
@@ -23,8 +27,7 @@ export default {
       number_of_movies: 50
     }
   }
-};
+}
 </script>
 
-<style lang="css" scoped>
-</style>
+<style lang="css" scoped></style>

--- a/app/src/views/Movie.vue
+++ b/app/src/views/Movie.vue
@@ -1,28 +1,45 @@
 <template>
   <div>
+    <div
+      class="min-h-screen bg-cover"
+      :style="{ backgroundImage: `url('${background}')` }"
+    >
+      <div class="pt-32 pl-8 mb-2"></div>
 
-  <div class="min-h-screen bg-cover" :style="{ backgroundImage: `url('${background}')` }">
-    <div class="pt-32 pl-8 mb-2">
+      <div class="pt-32 pl-24 mb-4">
+        <button
+          class="px-6 py-2 bg-white text-black font-bold uppercase rounded flex items-center hover:bg-gray-300"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+          >
+            <path d="M8 5v14l11-7z" />
+            <path d="M0 0h24v24H0z" fill="none" />
+          </svg>
+          <span class="pl-1">Play</span>
+        </button>
+      </div>
+
+      <div class="pl-24 text-gray-500 mb-8">
+        PG-13 &middot; 2019 &middot; 2h 4m &middot; Action, Adventure, Science
+        Fiction
+      </div>
+
+      <div class="w-96 xl:w-1/3 pl-24 leading-loose">
+        Lorem ipsum, dolor sit amet consectetur adipisicing elit. Natus fugit
+        tenetur velit quasi soluta sunt suscipit, eveniet dolorum. Tenetur
+        architecto voluptatum quis, vitae autem, vero tempora libero impedit
+        culpa debitis, quisquam nam nemo quidem modi sunt illo consequuntur
+        maiores magni.
+      </div>
+      <!-- <img src="@/assets/captain_marvel_background.jpg" alt="captain marvel"> -->
     </div>
-
-
-    <div class="pt-32 pl-24 mb-4">
-      <button class="px-6 py-2 bg-white text-black font-bold uppercase rounded flex items-center hover:bg-gray-300">
-        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M8 5v14l11-7z"></path><path d="M0 0h24v24H0z" fill="none"></path></svg>
-        <span class="pl-1">Play</span>
-      </button>
-    </div>
-
-    <div class="pl-24 text-gray-500 mb-8">
-      PG-13 &middot; 2019 &middot; 2h 4m &middot; Action, Adventure, Science Fiction
-    </div>
-
-    <div class="w-96 xl:w-1/3 pl-24 leading-loose">
-      Lorem ipsum, dolor sit amet consectetur adipisicing elit. Natus fugit tenetur velit quasi soluta sunt suscipit, eveniet dolorum. Tenetur architecto voluptatum quis, vitae autem, vero tempora libero impedit culpa debitis, quisquam nam nemo quidem modi sunt illo consequuntur maiores magni.
-    </div>
-    <!-- <img src="@/assets/captain_marvel_background.jpg" alt="captain marvel"> -->
-  </div>
-    <div class="bg-red-600 h-screen flex items-center justify-center uppercase text-white text-5xl">
+    <div
+      class="bg-red-600 h-screen flex items-center justify-center uppercase text-white text-5xl"
+    >
       <h1>Comments</h1>
     </div>
   </div>


### PR DESCRIPTION
Added Eslint and Prettier to the frontend directory.
`yarn run lint-fix` can be used to **format**, **lint** and **save** changes.
Using Vetur, Eslint and Prettier VSCode extensions with the `formatOnSave` parameter activated, the process is done *automatically*.